### PR TITLE
feat : 마이페이지 기능 구현

### DIFF
--- a/src/main/java/com/yukgaejang/inflearnclone/domain/login/config/SecurityConfig.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/login/config/SecurityConfig.java
@@ -69,7 +69,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
                         .requestMatchers(HttpMethod.PATCH, "/auth").authenticated()
-                        .requestMatchers(HttpMethod.DELETE, "auth").authenticated()
+                        .requestMatchers(HttpMethod.DELETE, "/auth").authenticated()
                         .requestMatchers(HttpMethod.POST, "/board/**").authenticated()
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/api/UserApi.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/api/UserApi.java
@@ -3,9 +3,13 @@ package com.yukgaejang.inflearnclone.domain.user.api;
 import com.yukgaejang.inflearnclone.domain.login.jwt.TokenProvider;
 import com.yukgaejang.inflearnclone.domain.login.util.SecurityUtil;
 import com.yukgaejang.inflearnclone.domain.user.application.UserService;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserBoardResponseDto;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserCommentResponseDto;
 import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,7 +28,8 @@ public class UserApi {
     private final TokenProvider tokenProvider;
 
     @GetMapping
-    public ResponseEntity<UserResponseDto> getUser(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader) {
+    public ResponseEntity<UserResponseDto> getUser(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader) {
         if (SecurityUtil.getCurrentUsername().get().equals("anonymousUser")) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
@@ -37,4 +43,39 @@ public class UserApi {
         return ResponseEntity.status(HttpStatus.OK).body(userResponseDto);
     }
 
+    @GetMapping("/board")
+    public ResponseEntity<Page<UserBoardResponseDto>> getUserBoard(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
+            @PageableDefault Pageable pageable,
+            @RequestParam(required = false) String sortBy) {
+        if (SecurityUtil.getCurrentUsername().get().equals("anonymousUser")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        String token = authorizationHeader.substring(7);
+        Authentication authentication = tokenProvider.getAuthentication(token);
+        String email = authentication.getName();
+
+        Page<UserBoardResponseDto> userBoardResponseDtoList = userService.getUserBoard(email, pageable, sortBy);
+
+        return ResponseEntity.status(HttpStatus.OK).body(userBoardResponseDtoList);
+    }
+
+    @GetMapping("/comment")
+    public ResponseEntity<Page<UserCommentResponseDto>> getUserComment(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader,
+            @PageableDefault Pageable pageable,
+            @RequestParam(required = false) String sortBy) {
+        if (SecurityUtil.getCurrentUsername().get().equals("anonymousUser")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        String token = authorizationHeader.substring(7);
+        Authentication authentication = tokenProvider.getAuthentication(token);
+        String email = authentication.getName();
+
+        Page<UserCommentResponseDto> userCommentResponseDtoList = userService.getUserComment(email, pageable, sortBy);
+
+        return ResponseEntity.status(HttpStatus.OK).body(userCommentResponseDtoList);
+    }
 }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/api/UserApi.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/api/UserApi.java
@@ -1,0 +1,40 @@
+package com.yukgaejang.inflearnclone.domain.user.api;
+
+import com.yukgaejang.inflearnclone.domain.login.jwt.TokenProvider;
+import com.yukgaejang.inflearnclone.domain.login.util.SecurityUtil;
+import com.yukgaejang.inflearnclone.domain.user.application.UserService;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+public class UserApi {
+    private final UserService userService;
+    private final TokenProvider tokenProvider;
+
+    @GetMapping
+    public ResponseEntity<UserResponseDto> getUser(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorizationHeader) {
+        if (SecurityUtil.getCurrentUsername().get().equals("anonymousUser")) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
+        }
+
+        String token = authorizationHeader.substring(7);
+        Authentication authentication = tokenProvider.getAuthentication(token);
+        String email = authentication.getName();
+
+        UserResponseDto userResponseDto = userService.getUser(email);
+
+        return ResponseEntity.status(HttpStatus.OK).body(userResponseDto);
+    }
+
+}

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/application/UserService.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/application/UserService.java
@@ -1,0 +1,19 @@
+package com.yukgaejang.inflearnclone.domain.user.application;
+
+import com.yukgaejang.inflearnclone.domain.user.dao.UserDao;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserDao userRepository;
+
+    public UserResponseDto getUser(String email) {
+        UserResponseDto userResponseDto = userRepository.getUserWithPostAndCommentCounts(email);
+        return userResponseDto;
+    }
+
+
+}

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/application/UserService.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/application/UserService.java
@@ -1,8 +1,12 @@
 package com.yukgaejang.inflearnclone.domain.user.application;
 
 import com.yukgaejang.inflearnclone.domain.user.dao.UserDao;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserBoardResponseDto;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserCommentResponseDto;
 import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,9 +15,14 @@ public class UserService {
     private final UserDao userRepository;
 
     public UserResponseDto getUser(String email) {
-        UserResponseDto userResponseDto = userRepository.getUserWithPostAndCommentCounts(email);
-        return userResponseDto;
+        return userRepository.getUserWithPostAndCommentCounts(email);
     }
 
+    public Page<UserBoardResponseDto> getUserBoard(String email, Pageable pageable, String sortBy) {
+        return userRepository.getUserBoardData(email, pageable, sortBy);
+    }
 
+    public Page<UserCommentResponseDto> getUserComment(String email, Pageable pageable, String sortBy) {
+        return userRepository.getUserCommentData(email, pageable, sortBy);
+    }
 }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDao.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDao.java
@@ -1,13 +1,15 @@
 package com.yukgaejang.inflearnclone.domain.user.dao;
 
 import com.yukgaejang.inflearnclone.domain.user.domain.User;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserBoardResponseDto;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserCommentResponseDto;
 import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface UserDao extends JpaRepository<User, Long>, UserDaoCustom {
 
     @EntityGraph(attributePaths = "authorities")
@@ -19,4 +21,10 @@ public interface UserDao extends JpaRepository<User, Long>, UserDaoCustom {
 
     @Override
     UserResponseDto getUserWithPostAndCommentCounts(String email);
+
+    @Override
+    Page<UserBoardResponseDto> getUserBoardData(String email, Pageable pageable, String sortBy);
+
+    @Override
+    Page<UserCommentResponseDto> getUserCommentData(String email, Pageable pageable, String sortBy);
 }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDao.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDao.java
@@ -1,13 +1,14 @@
 package com.yukgaejang.inflearnclone.domain.user.dao;
 
 import com.yukgaejang.inflearnclone.domain.user.domain.User;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserDao extends JpaRepository<User, Long> {
+public interface UserDao extends JpaRepository<User, Long>, UserDaoCustom {
 
     @EntityGraph(attributePaths = "authorities")
     Optional<User> findOneWithAuthoritiesByEmail(String email);
@@ -15,4 +16,7 @@ public interface UserDao extends JpaRepository<User, Long> {
     void deleteByEmail(String email);
 
     Optional<User> findByEmail(String email);
+
+    @Override
+    UserResponseDto getUserWithPostAndCommentCounts(String email);
 }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoCustom.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoCustom.java
@@ -1,7 +1,15 @@
 package com.yukgaejang.inflearnclone.domain.user.dao;
 
+import com.yukgaejang.inflearnclone.domain.user.dto.UserBoardResponseDto;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserCommentResponseDto;
 import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface UserDaoCustom {
     UserResponseDto getUserWithPostAndCommentCounts(String email);
+
+    Page<UserBoardResponseDto> getUserBoardData(String email, Pageable pageable, String sortBy);
+
+    Page<UserCommentResponseDto> getUserCommentData(String email, Pageable pageable, String sortBy);
 }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoCustom.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoCustom.java
@@ -1,0 +1,7 @@
+package com.yukgaejang.inflearnclone.domain.user.dao;
+
+import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
+
+public interface UserDaoCustom {
+    UserResponseDto getUserWithPostAndCommentCounts(String email);
+}

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoImpl.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoImpl.java
@@ -114,7 +114,6 @@ public class UserDaoImpl implements UserDaoCustom {
                 .where(QComment.comment.user.id.eq(userEntity.getId()))
                 .groupBy(QComment.comment.board.id)
                 .fetch();
-        System.out.println("boardIds: " + boardIds);
 
         if (boardIds.isEmpty()) {
             return Page.empty();
@@ -126,25 +125,24 @@ public class UserDaoImpl implements UserDaoCustom {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-        System.out.println("pagedBoardIds: " + pagedBoardIds);
 
         if (pagedBoardIds.isEmpty()) {
             return Page.empty();
         }
 
-        List<Tuple> boardAndComments = queryFactory.select(QBoard.board.id, QBoard.board.title, QComment.comment.content, QComment.comment.createdAt)
+        List<Tuple> boardAndComments = queryFactory.select(QBoard.board.id, QBoard.board.title, QComment.comment.id, QComment.comment.content, QComment.comment.createdAt)
                 .from(QBoard.board)
                 .leftJoin(QComment.comment).on(QBoard.board.id.eq(QComment.comment.board.id))
                 .where(QBoard.board.id.in(pagedBoardIds))
                 .orderBy(getCommentSortOrder(sortBy))
                 .fetch();
-        System.out.println("boardAndComments: " + boardAndComments);
 
         Map<Long, List<UserCommentDetailDto>> commentMap = boardAndComments.stream()
                 .collect(Collectors.groupingBy(
                         tuple -> tuple.get(QBoard.board.id),
                         Collectors.mapping(
                                 tuple -> new UserCommentDetailDto(
+                                        tuple.get(QComment.comment.id),
                                         tuple.get(QComment.comment.content),
                                         tuple.get(QComment.comment.createdAt)
                                 ),

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoImpl.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoImpl.java
@@ -1,12 +1,21 @@
 package com.yukgaejang.inflearnclone.domain.user.dao;
 
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.yukgaejang.inflearnclone.domain.board.domain.QBoard;
 import com.yukgaejang.inflearnclone.domain.comment.domain.QComment;
 import com.yukgaejang.inflearnclone.domain.user.domain.QUser;
 import com.yukgaejang.inflearnclone.domain.user.domain.User;
+import com.yukgaejang.inflearnclone.domain.user.dto.QUserBoardResponseDto;
+import com.yukgaejang.inflearnclone.domain.user.dto.QUserCommentResponseDto;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserBoardResponseDto;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserCommentResponseDto;
 import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -43,4 +52,115 @@ public class UserDaoImpl implements UserDaoCustom {
                 .build();
     }
 
+    @Override
+    public Page<UserBoardResponseDto> getUserBoardData(String email, Pageable pageable, String sortBy) {
+        User userEntity = queryFactory.selectFrom(QUser.user)
+                .where(QUser.user.email.eq(email))
+                .fetchOne();
+
+        if (userEntity == null) {
+            return Page.empty();
+        }
+
+        List<UserBoardResponseDto> userBoardList = queryFactory.select(
+                        new QUserBoardResponseDto(
+                                QBoard.board.id,
+                                QBoard.board.title,
+                                QBoard.board.createdAt,
+                                QBoard.board.updatedAt,
+                                QBoard.board.content.substring(0, 20),
+                                QBoard.board.category,
+                                QBoard.board.likeCount,
+                                QBoard.board.commentCount
+                        )
+                )
+                .from(QBoard.board)
+                .where(QBoard.board.user.id.eq(userEntity.getId()))
+                .orderBy(getBoardSortOrder(sortBy))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory.select(QBoard.board.count())
+                .from(QBoard.board)
+                .where(QBoard.board.user.id.eq(userEntity.getId()))
+                .fetchOne();
+
+        if (count == null) {
+            count = 0L;
+        }
+
+        return new PageImpl<>(userBoardList, pageable, count);
+    }
+
+    @Override
+    public Page<UserCommentResponseDto> getUserCommentData(String email, Pageable pageable, String sortBy) {
+        QComment commentSub = new QComment("commentSub");
+
+        User userEntity = queryFactory.selectFrom(QUser.user)
+                .where(QUser.user.email.eq(email))
+                .fetchOne();
+
+        if (userEntity == null) {
+            return Page.empty();
+        }
+
+        List<Long> latestCommentIds = queryFactory.select(commentSub.id.max())
+                .from(commentSub)
+                .where(commentSub.user.id.eq(userEntity.getId()))
+                .groupBy(commentSub.board.id)
+                .fetch();
+
+        List<UserCommentResponseDto> userCommentList = queryFactory.select(
+                        new QUserCommentResponseDto(
+                                QBoard.board.id,
+                                QBoard.board.title,
+                                QComment.comment.content,
+                                QComment.comment.createdAt
+                        )
+                )
+                .from(QComment.comment)
+                .join(QComment.comment.board, QBoard.board)
+                .where(QComment.comment.id.in(latestCommentIds))
+                .orderBy(getCommentSortOrder(sortBy))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long count = queryFactory.select(QBoard.board.countDistinct())
+                .from(QComment.comment)
+                .join(QComment.comment.board, QBoard.board)
+                .where(QComment.comment.id.in(latestCommentIds))
+                .fetchOne();
+
+        if (count == null) {
+            count = 0L;
+        }
+
+        return new PageImpl<>(userCommentList, pageable, count);
+    }
+
+    private OrderSpecifier<?> getBoardSortOrder(String sortBy) {
+        if (sortBy == null) {
+            return QBoard.board.createdAt.desc();
+        } else if (sortBy.equals("likeCount")) {
+            return QBoard.board.likeCount.desc();
+        } else if (sortBy.equals("viewCount")) {
+            return QBoard.board.viewCount.desc();
+        } else {
+            return QBoard.board.createdAt.desc();
+        }
+    }
+
+    private OrderSpecifier<?> getCommentSortOrder(String sortBy) {
+        if (sortBy == null) {
+            return QComment.comment.createdAt.desc();
+        } else if (sortBy.equals("likeCount")) {
+            return QBoard.board.likeCount.desc();
+        } else if (sortBy.equals("viewCount")) {
+            return QBoard.board.viewCount.desc();
+        } else {
+            return QComment.comment.createdAt.desc();
+        }
+    }
 }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoImpl.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dao/UserDaoImpl.java
@@ -1,0 +1,46 @@
+package com.yukgaejang.inflearnclone.domain.user.dao;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.yukgaejang.inflearnclone.domain.board.domain.QBoard;
+import com.yukgaejang.inflearnclone.domain.comment.domain.QComment;
+import com.yukgaejang.inflearnclone.domain.user.domain.QUser;
+import com.yukgaejang.inflearnclone.domain.user.domain.User;
+import com.yukgaejang.inflearnclone.domain.user.dto.UserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+@RequiredArgsConstructor
+public class UserDaoImpl implements UserDaoCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public UserResponseDto getUserWithPostAndCommentCounts(String email) {
+        User userEntity = queryFactory.selectFrom(QUser.user)
+                .where(QUser.user.email.eq(email))
+                .fetchOne();
+
+        if (userEntity == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 사용자 입니다");
+        }
+
+        Long boardCount = queryFactory.select(QBoard.board.count())
+                .from(QBoard.board)
+                .where(QBoard.board.user.id.eq(userEntity.getId()))
+                .fetchOne();
+
+        Long commentCount = queryFactory.select(QComment.comment.count())
+                .from(QComment.comment)
+                .where(QComment.comment.user.id.eq(userEntity.getId()))
+                .fetchOne();
+
+        return UserResponseDto.builder()
+                .email(userEntity.getEmail())
+                .nickname(userEntity.getNickname())
+                .profileImage(userEntity.getProfileImage())
+                .boardCount(boardCount)
+                .commentCount(commentCount)
+                .build();
+    }
+
+}

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserBoardResponseDto.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserBoardResponseDto.java
@@ -1,0 +1,34 @@
+package com.yukgaejang.inflearnclone.domain.user.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserBoardResponseDto {
+    private Long id;
+    private String title;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String content; // 20글자까지만 보여주기
+    private String category;
+    private Long likeCount;
+    private Long commentCount;
+
+    @QueryProjection
+    public UserBoardResponseDto(Long id, String title, LocalDateTime createdAt, LocalDateTime updatedAt, String content,
+                                String category, Long likeCount, Long commentCount) {
+        this.id = id;
+        this.title = title;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.content = content;
+        this.category = category;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+    }
+}

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentDetailBoardDto.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentDetailBoardDto.java
@@ -1,7 +1,6 @@
 package com.yukgaejang.inflearnclone.domain.user.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -9,15 +8,13 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class UserCommentResponseDto {
+public class UserCommentDetailBoardDto {
     private Long id;
     private String title;
-    private List<UserCommentDetailDto> comments;
 
     @QueryProjection
-    public UserCommentResponseDto(Long id, String title, List<UserCommentDetailDto> comments) {
+    public UserCommentDetailBoardDto(Long id, String title) {
         this.id = id;
         this.title = title;
-        this.comments = comments;
     }
 }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentDetailDto.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentDetailDto.java
@@ -9,10 +9,12 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class UserCommentDetailDto {
+    private Long commentId;
     private String content;
     private LocalDateTime createdAt;
 
-    public UserCommentDetailDto(String content, LocalDateTime createdAt) {
+    public UserCommentDetailDto(Long commentId, String content, LocalDateTime createdAt) {
+        this.commentId = commentId;
         this.content = content;
         this.createdAt = createdAt;
     }

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentDetailDto.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentDetailDto.java
@@ -1,0 +1,19 @@
+package com.yukgaejang.inflearnclone.domain.user.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserCommentDetailDto {
+    private String content;
+    private LocalDateTime createdAt;
+
+    public UserCommentDetailDto(String content, LocalDateTime createdAt) {
+        this.content = content;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentResponseDto.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserCommentResponseDto.java
@@ -1,0 +1,25 @@
+package com.yukgaejang.inflearnclone.domain.user.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserCommentResponseDto {
+    private Long id;
+    private String title;
+    private String comment;
+    private LocalDateTime createdAt;
+
+    @QueryProjection
+    public UserCommentResponseDto(Long id, String title, String comment, LocalDateTime createdAt) {
+        this.id = id;
+        this.title = title;
+        this.comment = comment;
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/yukgaejang/inflearnclone/domain/user/dto/UserResponseDto.java
@@ -1,0 +1,28 @@
+package com.yukgaejang.inflearnclone.domain.user.dto;
+
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserResponseDto {
+    @Column(name = "email", length = 50)
+    private String email;
+
+    @Column(name = "nickname", length = 50)
+    private String nickname;
+
+    @Column(name = "profile_image")
+    private String profileImage;
+
+    Long boardCount;
+
+    Long commentCount;
+}


### PR DESCRIPTION
### 회원 정보 조회 기능 구현
- 회원 이메일, 닉네임, 이미지, 게시글 수, 댓글 수 반환

### 내가 쓴 게시글 기능 구현
- 내가 작성한 게시글 정보를 반환
- 페이징 처리하여 전달
- 파라미터로 정렬 기준 전달하면 정렬해서 반환(ex. localhost:8080/user/board?page=0&size=5&sortBy=likeCount)
- likeCount는 좋아요순, viewCount는 조회순, 담지않고 전달하면 최신순으로 반환

### 내가 쓴 댓글 기능 구현
- 내가 작성한 댓글의 게시글 정보와 댓글 정보를 반환
- 파라미터로 정렬 기준 전달하면 정렬해서 반환(ex. localhost:8080/user/comment?page=0&size=5&sortBy=likeCount)
- likeCount는 좋아요순, viewCount는 조회순, 담지않고 전달하면 최신순으로 반환